### PR TITLE
Fix fsnotify dependency by adding source in Gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,7 @@
 [[constraint]]
   name = "gopkg.in/fsnotify.v1"
   version = "1.4.7"
+  source = "https://github.com/fsnotify/fsnotify.git"
 
 [prune]
   go-tests = true


### PR DESCRIPTION
Fix `gopkg.in/fsnotify.v1` constraint by pinning the `source` in `Gopkg.toml` as suggested in https://github.com/golang/dep/issues/1799#issuecomment-381026769.